### PR TITLE
FIX für den Fehler Cannot use object of type Closure

### DIFF
--- a/system/modules/clipboard/classes/ClipboardXmlReader.php
+++ b/system/modules/clipboard/classes/ClipboardXmlReader.php
@@ -198,8 +198,16 @@ class ClipboardXmlReader extends Backend
                             {
                                     foreach ($GLOBALS['TL_DCA'][$strTable]['config']['oncopy_callback'] as $callback)
                                     {
+                                        // Use the Method from DC_Table.php Line 999 ff
+                                        if (is_array($callback))
+                                        {
                                             $this->import($callback[0]);
                                             $this->{$callback[0]}->{$callback[1]}($intLastInsertId, $dc);
+                                        }
+                                        elseif (is_callable($callback))
+                                        {
+                                            $callback($intLastInsertId, $dc);
+                                        }
                                     }
                             }
                             $this->Input->setGet('act', NULL);


### PR DESCRIPTION
Um den Fehler 
Fatal error: Cannot use object of type Closure as array in /../../composer/vendor/menatwork/clipboard/system/modules/clipboard/classes/ClipboardXmlReader.php on line 201 zu vermeiden sollte die aktuelle  Methode zum Aufrufen der oncopy_callback Funkionen verwendet werden